### PR TITLE
Transparent Proxy MDM Example missing required key

### DIFF
--- a/examples/filtering/mdm/MSP Filtering (TP).mobileconfig
+++ b/examples/filtering/mdm/MSP Filtering (TP).mobileconfig
@@ -48,7 +48,8 @@
 					<string>anchor apple generic and identifier "com.ZorusTech.Filtering.Redirectors.macOS.Extension" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = X2G78PSXBN)</string>
 					<key>ProviderType</key>
 					<string>app-proxy</string>
-
+					<key>RemoteAddress</key>
+					<string>mspfilteringtp.local</string>
 				</dict>
 				<key>UserDefinedName</key>
 				<string>MSP Filtering (TP)</string>


### PR DESCRIPTION
Accidentally missed a required key for the macOS MDM transparent proxy profile.

----

fix(transparent-proxy-mdm-filtering): Adding a missing key to the Transparent Proxy MDM profile for Filtering.