### PR TITLE
[FLTR-133] MacOS DNS Network Filter MDM Payload Missing Provider Requirements

### DIFF
--- a/examples/macOS/mdm/MSP Filtering (DNS).mobileconfig
+++ b/examples/macOS/mdm/MSP Filtering (DNS).mobileconfig
@@ -27,6 +27,8 @@
                 <integer>1</integer>
                 <key>ProviderBundleIdentifier</key>
                 <string>com.ZorusTech.Filtering.Redirectors.macOS.Extension</string>
+				<key>ProviderDesignatedRequirement</key>
+				<string>anchor apple generic and identifier "com.ZorusTech.Filtering.Redirectors.macOS.Extension" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = X2G78PSXBN)</string>
             </dict>
         </array>
         <key>PayloadRemovalDisallowed</key>


### PR DESCRIPTION
fix(macos-mdm-dns-proxy): Fixing an issue where the DNS Network Filter MDM payload would not allow the agent to work due to missing provider requirements.