### PR TITLE
Fixing Quotes on macOS MDM Diagnostic Logging Profile

### DIFF
--- a/examples/macOS/mdm/MSP Filtering (Diagnostic Logging).mobileconfig
+++ b/examples/macOS/mdm/MSP Filtering (Diagnostic Logging).mobileconfig
@@ -1,6 +1,6 @@
-<?xml version=”1.0” encoding=”UTF-8”?>
-<!DOCTYPE plist PUBLIC “-//Apple//DTD PLIST 1.0//EN” “http://www.apple.com/DTDs/PropertyList-1.0.dtd”>
-<plist version=”1.0”>
+<?xml version="1.0" encoding=”UTF-8”?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
     <dict>
         <key>PayloadDisplayName</key>
         <string>MSP Filtering Diagnostic Logging Profile</string>

--- a/examples/macOS/mdm/MSP Filtering (Diagnostic Logging).mobileconfig
+++ b/examples/macOS/mdm/MSP Filtering (Diagnostic Logging).mobileconfig
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding=”UTF-8”?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>


### PR DESCRIPTION
Issue was likely caused because of using TextEdit.app on macOS, which can try to make documents "nice", and in this case made use of the "proper" quotes for a document, but not for an MDM profile.

-----

fix(macos-mdm-diagnostic-logging): Fixing an issue where the MDM profile for diagnostic logging had badly-copied formatting.