### PR TITLE
Fixed credential read issue in MacOS Forced Reinstall script

### DIFF
--- a/scripts/macOS/ForcedReinstall.zsh
+++ b/scripts/macOS/ForcedReinstall.zsh
@@ -55,7 +55,7 @@ getJsonValue() {
 # Secondly check if we have an available deployment token from the current endpoint.
 if [[ -z "$ZORUS_DEPLOYMENT_TOKEN" && -f "$ZORUS_CREDENTIALS_FILE" ]]
 then
-    CREDENTIAL_FILE_DATA=$(cat $ZORUS_CREDENTIALS_FILE)
+    CREDENTIAL_FILE_DATA=$(cat "$ZORUS_CREDENTIALS_FILE")
     ZORUS_DEPLOYMENT_TOKEN=$(getJsonValue "$CREDENTIAL_FILE_DATA" 'CredentialSettings.DeploymentKey')
     echo "Found Zorus Deployment Token $ZORUS_DEPLOYMENT_TOKEN."
 fi


### PR DESCRIPTION
Update ForcedReinstall.zsh to add quotes around credential file variable on line 58 - was causing cat to incorrectly parse the credentials file path