### PR TITLE
fix: removed legacy hide tray icon flag from the installer script

### DIFF
--- a/scripts/windows/InstallScript.ps1
+++ b/scripts/windows/InstallScript.ps1
@@ -1,6 +1,5 @@
 $Token = "";
 $Password = "";
-$trayIcon = 0; # default is 0
 $addRemove = 0; # default is 0
 
 $originalProtocol = [System.Net.ServicePointManager]::SecurityProtocol
@@ -42,12 +41,12 @@ catch
 if ([string]::IsNullOrEmpty($Password))
 {
     Write-Host "Installing Zorus Deployment Agent..."
-    Start-Process -FilePath $destination -ArgumentList "/qn", "ARCHON_TOKEN=$Token", "HIDE_TRAY_ICON=$trayIcon", "HIDE_ADD_REMOVE=$addRemove" -Wait
+    Start-Process -FilePath $destination -ArgumentList "/qn", "ARCHON_TOKEN=$Token", "HIDE_ADD_REMOVE=$addRemove" -Wait
 }
 else
 {
     Write-Host "Installing Zorus Deployment Agent with password..."
-    Start-Process -FilePath $destination -ArgumentList "/qn", "ARCHON_TOKEN=$Token", "HIDE_TRAY_ICON=$trayIcon", "HIDE_ADD_REMOVE=$addRemove", "UNINSTALL_PASSWORD=$Password" -Wait
+    Start-Process -FilePath $destination -ArgumentList "/qn", "ARCHON_TOKEN=$Token", "HIDE_ADD_REMOVE=$addRemove", "UNINSTALL_PASSWORD=$Password" -Wait
 }
 
 Write-Host "Removing temporary files..."


### PR DESCRIPTION
the hide tray icon option should be set from the portal. the installer option is legacy logic and is overridden by what value is set in the portal deeming this flag useless.