### PR TITLE
Main

### DIFF
--- a/scripts/windows/InstallScript.ps1
+++ b/scripts/windows/InstallScript.ps1
@@ -2,8 +2,8 @@ $Token = "";
 $Password = "";
 $addRemove = 0; # default is 0
 
-$originalProtocol = [System.Net.ServicePointManager]::SecurityProtocol
-[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::'SystemDefault'
+# Set TLS 1.2 in a manner compatible with older .Net installations.
+[Net.ServicePointManager]::SecurityProtocol = [Enum]::ToObject([Net.SecurityProtocolType], 3072)
 
 # Determine whether or not the agent is already installed
 $InstalledSoftware = Get-ChildItem "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall"
@@ -52,5 +52,3 @@ else
 Write-Host "Removing temporary files..."
 Remove-Item -recurse $destination
 Write-Host "Installation complete."
-
-[System.Net.ServicePointManager]::SecurityProtocol = $originalProtocol

--- a/scripts/windows/UninstallScript.ps1
+++ b/scripts/windows/UninstallScript.ps1
@@ -1,7 +1,7 @@
 $Password = ""
 
-$originalProtocol = [System.Net.ServicePointManager]::SecurityProtocol
-[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::'SystemDefault'
+# Set TLS 1.2 in a manner compatible with older .Net installations.
+[Net.ServicePointManager]::SecurityProtocol = [Enum]::ToObject([Net.SecurityProtocolType], 3072)
 
 $source = "https://static.zorustech.com/downloads/ZorusAgentRemovalTool.exe";
 $destination = "$env:TEMP\ZorusAgentRemovalTool.exe";
@@ -32,5 +32,3 @@ else
 Write-Host "Removing temporary files..."
 Remove-Item -recurse $destination
 Write-Host "Removal complete."
-
-[System.Net.ServicePointManager]::SecurityProtocol = $originalProtocol

--- a/scripts/windows/UpdateScript.ps1
+++ b/scripts/windows/UpdateScript.ps1
@@ -2,8 +2,8 @@
 # Please do NOT use this for fresh installs as it doesn't allow input for
 # deployment tokens and other necessary first time install variables.
 
-$originalProtocol = [System.Net.ServicePointManager]::SecurityProtocol
-[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::'SystemDefault'
+# Set TLS 1.2 in a manner compatible with older .Net installations.
+[Net.ServicePointManager]::SecurityProtocol = [Enum]::ToObject([Net.SecurityProtocolType], 3072)
 
 $source = "https://static.zorustech.com/downloads/ZorusInstaller.exe"
 $destination = "$env:TEMP\ZorusInstaller.exe"
@@ -26,5 +26,3 @@ Start-Process -FilePath $destination -ArgumentList @('/qn ALLUSERS="1" AUTO_UPGR
 Write-Host "Removing temporary files..."
 Remove-Item -recurse $destination
 Write-Host "Update complete."
-
-[System.Net.ServicePointManager]::SecurityProtocol = $originalProtocol


### PR DESCRIPTION
Address issue #16 - Set script to use TLS 1.2 in a manner compatable with older .Net installations.

Removed saving and restoration of current settings as these will be reverted to default values as soon as the powershell.exe process terminates.